### PR TITLE
add block atlases for 1.20

### DIFF
--- a/assets/minecraft/atlases/blocks.json
+++ b/assets/minecraft/atlases/blocks.json
@@ -1,0 +1,24 @@
+{
+    "sources": [
+        {
+            "type": "directory",
+            "source": "dt",
+            "prefix": "dt/"
+        },
+        {
+            "type": "directory",
+            "source": "tardis",
+            "prefix": "tardis/"
+        },
+        {
+            "type": "directory",
+            "source": "glowing",
+            "prefix": "glowing/"
+        },
+        {
+            "type": "directory",
+            "source": "painting",
+            "prefix": "painting/"
+        }
+    ]
+}


### PR DESCRIPTION
Fix for the missing textures due to the atlas update from snapshot 22w42a